### PR TITLE
Add response_validation_exclude_routes support

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,9 +1,5 @@
 Changelog
 =========
-2.9.0 (2024-5-06)
-++++++++++++++++++++++++++
-* Add response_validation_exclude_routes support (see #253)
-
 2.8.0 (2024-5-03)
 ++++++++++++++++++++++++++
 * Ensure http 401 in case of missing security (see #239)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,10 @@
 Changelog
 =========
+2.9.0 (2024-5-06)
+++++++++++++++++++++++++++
+* Add response_validation_exclude_routes support (see #253)
 
-2.8.0 (2024--5-03)
+2.8.0 (2024-5-03)
 ++++++++++++++++++++++++++
 * Ensure http 401 in case of missing security (see #239)
 * Fix pyramid swagger renderer if missing schema (see #242)
@@ -9,7 +12,7 @@ Changelog
 * Minor fixes (see #243, #244 and #246)
 * Update tox to py38 and py310 and skip swagger 1.2 tests (see #249)
 
-2.7.0 (2019--5-07)
+2.7.0 (2019-5-07)
 ++++++++++++++++++++++++++
 * Remove not needed deprecation warnings (see #238)
 * Make ``pyramid_swagger`` compatible with ``jsonschema>3`` (see #327)

--- a/pyramid_swagger/__about__.py
+++ b/pyramid_swagger/__about__.py
@@ -13,7 +13,7 @@ __title__ = "pyramid_swagger"
 __summary__ = "Swagger tools for use in pyramid webapps"
 __uri__ = "https://github.com/striglia/pyramid_swagger"
 
-__version__ = "2.9.0"
+__version__ = "2.8.0"
 
 __author__ = "Scott Triglia"
 __email__ = "scott.triglia@gmail.com"

--- a/pyramid_swagger/__about__.py
+++ b/pyramid_swagger/__about__.py
@@ -13,7 +13,7 @@ __title__ = "pyramid_swagger"
 __summary__ = "Swagger tools for use in pyramid webapps"
 __uri__ = "https://github.com/striglia/pyramid_swagger"
 
-__version__ = "2.8.0"
+__version__ = "2.9.0"
 
 __author__ = "Scott Triglia"
 __email__ = "scott.triglia@gmail.com"

--- a/pyramid_swagger/tween.py
+++ b/pyramid_swagger/tween.py
@@ -469,7 +469,6 @@ def should_exclude_request(settings, request, route_info):
 
 
 def should_exclude_response_validation(settings, route_info):
-    print(route_info)
     return should_exclude_route(settings.response_validation_exclude_routes, route_info)
 
 

--- a/tests/acceptance/app/config.ini
+++ b/tests/acceptance/app/config.ini
@@ -8,3 +8,5 @@ pyramid_swagger.exclude_routes = /undefined/first
 pyramid_swagger.prefer_20_routes = /sample
 pyramid_swagger.schema_directory = tests/sample_schemas/good_app
 pyramid_swagger.swagger_versions = 1.2 2.0
+pyramid_swagger.response_validation_exclude_routes = /exclude_response/first
+                                                     /exclude_response/second

--- a/tests/acceptance/config_ini_test.py
+++ b/tests/acceptance/config_ini_test.py
@@ -31,6 +31,7 @@ def test_load_ini_settings(ini_app):
     assert settings.validate_path is True
     assert settings.exclude_routes == {'/undefined/first', '/undefined/second'}
     assert settings.prefer_20_routes == {'/sample'}
+    assert settings.response_validation_exclude_routes == {'/exclude_response/first', '/exclude_response/second'}
 
 
 def test_get_swagger_versions(ini_app):

--- a/tests/tween_test.py
+++ b/tests/tween_test.py
@@ -31,6 +31,7 @@ from pyramid_swagger.tween import PyramidSwaggerRequest
 from pyramid_swagger.tween import PyramidSwaggerResponse
 from pyramid_swagger.tween import Settings
 from pyramid_swagger.tween import should_exclude_path
+from pyramid_swagger.tween import should_exclude_response_validation
 from pyramid_swagger.tween import should_exclude_route
 from pyramid_swagger.tween import SWAGGER_12
 from pyramid_swagger.tween import SWAGGER_20
@@ -106,6 +107,21 @@ def test_should_exclude_route_no_matched_route(mock_route_info):
 
 def test_should_exclude_route_no_route():
     assert not should_exclude_route(set(['foo', 'two']), {'route': None})
+
+
+def test_should_exclude_response_validation(settings, mock_route_info):
+    settings.response_validation_exclude_routes = ['route-one', 'two']
+    assert should_exclude_response_validation(settings, mock_route_info)
+
+
+def test_should_exclude_response_validation_no_matched_route(settings, mock_route_info):
+    settings.response_validation_exclude_routes = ['foo', 'two']
+    assert not should_exclude_response_validation(settings, mock_route_info)
+
+
+def test_should_exclude_response_validation_no_route():
+    settings.response_validation_exclude_routes = ['foo', 'two']
+    assert not should_exclude_response_validation(settings, {'route': None})
 
 
 def test_validation_skips_path_properly():


### PR DESCRIPTION
We want to add the ability to exclude routes for only response validation (while keep request response)