### PR TITLE
Add license metadata via classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
 
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.10',
+
+        'License :: OSI Approved :: BSD License',
     ],
     keywords='pyramid swagger validation',
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),


### PR DESCRIPTION
## Problem

Our system does not recognize the license text `BSD 3-clause` in `pyramid_swager.__about__`.

## Solution

Add BSD license classifier

## Notes

While `license` is a free-form way to specify the licence in setuptools, classifiers have a standard notation that is machine consumable (https://pypi.org/classifiers/) 